### PR TITLE
Create a `MarkdownEditor` component based on QuillJS (vibe-kanban)

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "bun-plugin-tailwind": "latest",
         "quill": "^2.0.3",
+        "quilljs-markdown": "^1.2.0",
         "react": "^19",
         "react-dom": "^19",
         "tailwindcss": "^4",
@@ -30,6 +31,8 @@
 
     "bun-types": ["bun-types@1.2.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ=="],
 
+    "core-js": ["core-js@3.44.0", "", {}, "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw=="],
+
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
@@ -48,9 +51,13 @@
 
     "quill-delta": ["quill-delta@5.1.0", "", { "dependencies": { "fast-diff": "^1.3.0", "lodash.clonedeep": "^4.5.0", "lodash.isequal": "^4.5.0" } }, "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA=="],
 
+    "quilljs-markdown": ["quilljs-markdown@1.2.0", "", { "dependencies": { "core-js": "^3.23.5", "regenerator-runtime": "^0.13.9" } }, "sha512-/Fqm0d7QF+n3dvFGZDosq5W4kBloD4QR6qDzv6ATFAmShDYRtnijP0cODmG+bk+2P+233wivbragV+6DNzePJg=="],
+
     "react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
 
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
+
+    "regenerator-runtime": ["regenerator-runtime@0.13.11", "", {}, "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="],
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "bun-plugin-tailwind": "latest",
     "quill": "^2.0.3",
+    "quilljs-markdown": "^1.2.0",
     "react": "^19",
     "react-dom": "^19",
     "tailwindcss": "^4"

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,6 @@
 import { APITester } from "./api_tester/components/APITester";
 import Editor from "./md_editor/components/Editor";
+import MarkdownEditor from "./components/markdown_editor";
 import "./index.css";
 
 import logo from "./logo.svg";
@@ -17,8 +18,46 @@ export function App() {
       <p>
         Edit <code>src/App.tsx</code> and save to test HMR
       </p>
-      <APITester />
-      <Editor />
+      
+      <div className="section">
+        <h2>Markdown Editor</h2>
+        <MarkdownEditor 
+          initialValue="# Welcome to Markdown Editor
+
+This is a **powerful** markdown editor built with *QuillJS*!
+
+## Features
+
+- Syntax highlighting for code blocks
+- Real-time markdown conversion
+- Keyboard shortcuts
+- Rich text editing
+
+### Code Example
+
+```javascript
+const hello = 'world';
+console.log(hello);
+```
+
+> This is a blockquote example
+
+Start typing to see the magic happen!"
+          onChange={(html, markdown) => {
+            console.log('Content changed:', { html, markdown });
+          }}
+        />
+      </div>
+      
+      <div className="section">
+        <h2>Original Editor</h2>
+        <Editor />
+      </div>
+      
+      <div className="section">
+        <h2>API Tester</h2>
+        <APITester />
+      </div>
     </div>
   );
 }

--- a/app/src/components/markdown_editor/MarkdownEditor.tsx
+++ b/app/src/components/markdown_editor/MarkdownEditor.tsx
@@ -1,0 +1,395 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type Quill from 'quill';
+import type { Delta } from 'quill';
+
+interface MarkdownEditorProps {
+  initialValue?: string;
+  onChange?: (content: string, markdown: string) => void;
+  placeholder?: string;
+  readOnly?: boolean;
+  className?: string;
+}
+
+export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+  initialValue = '',
+  onChange,
+  placeholder = 'Start typing markdown...',
+  readOnly = false,
+  className = '',
+}) => {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const quillRef = useRef<Quill | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    
+    const initializeEditor = async () => {
+      if (!editorRef.current || !window.Quill) return;
+
+      try {
+        // Load highlight.js for syntax highlighting
+        if (!window.hljs) {
+          await new Promise<void>((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = '/assets/highlight/highlight.min.js';
+            script.onload = () => resolve();
+            script.onerror = reject;
+            document.head.appendChild(script);
+          });
+        }
+
+        // Load additional languages for highlight.js
+        const languages = ['javascript', 'typescript', 'python', 'css', 'html', 'json', 'bash', 'rust', 'go'];
+        await Promise.all(languages.map(lang => {
+          return new Promise<void>((resolve) => {
+            const script = document.createElement('script');
+            script.src = `/assets/highlight/languages/${lang}.min.js`;
+            script.onload = () => resolve();
+            script.onerror = () => resolve(); // Continue even if language fails to load
+            document.head.appendChild(script);
+          });
+        }));
+
+        // Load GitHub theme for syntax highlighting
+        if (!document.querySelector('link[href*="github.min.css"]')) {
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.href = '/assets/highlight/styles/github.min.css';
+          document.head.appendChild(link);
+        }
+
+        if (!mounted) return;
+
+        // Initialize Quill with enhanced configuration
+        const quill = new window.Quill(editorRef.current, {
+          theme: 'snow',
+          placeholder,
+          readOnly,
+          modules: {
+            toolbar: [
+              [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+              ['bold', 'italic', 'underline', 'strike'],
+              ['blockquote', 'code-block'],
+              [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+              ['link', 'image'],
+              ['clean']
+            ],
+            syntax: {
+              highlight: (text: string) => {
+                if (window.hljs) {
+                  return window.hljs.highlightAuto(text).value;
+                }
+                return text;
+              }
+            },
+            history: {
+              delay: 1000,
+              maxStack: 100,
+              userOnly: true
+            }
+          },
+          formats: [
+            'header', 'bold', 'italic', 'underline', 'strike',
+            'blockquote', 'code-block', 'code', 'link', 'image', 'list'
+          ]
+        });
+
+        quillRef.current = quill;
+
+        // Set initial content
+        if (initialValue) {
+          quill.setText(initialValue);
+        }
+
+        // Enhanced text change handler with markdown conversion
+        quill.on('text-change', (delta: Delta, oldDelta: Delta, source: string) => {
+          if (source === 'user') {
+            const htmlContent = quill.root.innerHTML;
+            const textContent = quill.getText();
+            
+            // Process markdown-like syntax in real-time
+            processMarkdownSyntax(quill, delta);
+            
+            // Simple markdown conversion from rich text
+            const markdownContent = convertToMarkdown(quill.getContents());
+            
+            onChange?.(htmlContent, markdownContent);
+          }
+        });
+
+        // Apply markdown shortcuts
+        setupMarkdownShortcuts(quill);
+
+        setIsReady(true);
+        setIsLoading(false);
+
+      } catch (error) {
+        console.error('Error initializing markdown editor:', error);
+        setIsLoading(false);
+      }
+    };
+
+    // Wait for Quill to be available
+    if (window.Quill) {
+      initializeEditor();
+    } else {
+      // Fallback if Quill is not loaded yet
+      const checkQuill = setInterval(() => {
+        if (window.Quill) {
+          clearInterval(checkQuill);
+          initializeEditor();
+        }
+      }, 100);
+
+      return () => {
+        clearInterval(checkQuill);
+        mounted = false;
+      };
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, [initialValue, onChange, placeholder, readOnly]);
+
+  // Process markdown syntax in real-time
+  const processMarkdownSyntax = (quill: Quill, delta: Delta) => {
+    const text = quill.getText();
+    const selection = quill.getSelection();
+    
+    if (!selection) return;
+    
+    // Get the current line
+    const lines = text.split('\n');
+    const currentLineIndex = text.substr(0, selection.index).split('\n').length - 1;
+    const currentLine = lines[currentLineIndex];
+    
+    // Process headers (# ## ###)
+    const headerMatch = currentLine.match(/^(#{1,6})\s(.+)$/);
+    if (headerMatch) {
+      const level = headerMatch[1].length;
+      const content = headerMatch[2];
+      
+      setTimeout(() => {
+        const lineStart = text.indexOf(currentLine);
+        quill.deleteText(lineStart, currentLine.length, 'silent');
+        quill.insertText(lineStart, content, 'silent');
+        quill.formatLine(lineStart, content.length, 'header', level, 'silent');
+      }, 0);
+    }
+    
+    // Process bold (**text**)
+    const boldMatch = currentLine.match(/\*\*([^*]+)\*\*/g);
+    if (boldMatch) {
+      boldMatch.forEach(match => {
+        const content = match.replace(/\*\*/g, '');
+        const start = text.indexOf(match);
+        setTimeout(() => {
+          quill.deleteText(start, match.length, 'silent');
+          quill.insertText(start, content, { bold: true }, 'silent');
+        }, 0);
+      });
+    }
+    
+    // Process italic (*text*)
+    const italicMatch = currentLine.match(/\*([^*]+)\*/g);
+    if (italicMatch) {
+      italicMatch.forEach(match => {
+        const content = match.replace(/\*/g, '');
+        const start = text.indexOf(match);
+        setTimeout(() => {
+          quill.deleteText(start, match.length, 'silent');
+          quill.insertText(start, content, { italic: true }, 'silent');
+        }, 0);
+      });
+    }
+    
+    // Process inline code (`code`)
+    const codeMatch = currentLine.match(/`([^`]+)`/g);
+    if (codeMatch) {
+      codeMatch.forEach(match => {
+        const content = match.replace(/`/g, '');
+        const start = text.indexOf(match);
+        setTimeout(() => {
+          quill.deleteText(start, match.length, 'silent');
+          quill.insertText(start, content, { code: true }, 'silent');
+        }, 0);
+      });
+    }
+  };
+
+  // Helper function to convert Quill Delta to Markdown
+  const convertToMarkdown = (contents: Delta): string => {
+    let markdown = '';
+    
+    contents.ops?.forEach(op => {
+      if (typeof op.insert === 'string') {
+        let text = op.insert;
+        
+        if (op.attributes) {
+          if (op.attributes.bold) {
+            text = `**${text}**`;
+          }
+          if (op.attributes.italic) {
+            text = `*${text}*`;
+          }
+          if (op.attributes.code) {
+            text = `\`${text}\``;
+          }
+          if (op.attributes.link) {
+            text = `[${text}](${op.attributes.link})`;
+          }
+          if (op.attributes.header) {
+            const level = op.attributes.header;
+            text = `${'#'.repeat(level)} ${text}`;
+          }
+        }
+        
+        markdown += text;
+      }
+    });
+    
+    return markdown;
+  };
+
+  // Setup markdown shortcuts
+  const setupMarkdownShortcuts = (quill: Quill) => {
+    // Header shortcuts
+    quill.keyboard.addBinding({
+      key: '1',
+      ctrlKey: true,
+      altKey: true,
+      handler: () => {
+        const range = quill.getSelection();
+        if (range) {
+          quill.formatLine(range.index, range.length, 'header', 1);
+        }
+      }
+    });
+
+    quill.keyboard.addBinding({
+      key: '2',
+      ctrlKey: true,
+      altKey: true,
+      handler: () => {
+        const range = quill.getSelection();
+        if (range) {
+          quill.formatLine(range.index, range.length, 'header', 2);
+        }
+      }
+    });
+
+    quill.keyboard.addBinding({
+      key: '3',
+      ctrlKey: true,
+      altKey: true,
+      handler: () => {
+        const range = quill.getSelection();
+        if (range) {
+          quill.formatLine(range.index, range.length, 'header', 3);
+        }
+      }
+    });
+
+    // Code block shortcut
+    quill.keyboard.addBinding({
+      key: 'E',
+      ctrlKey: true,
+      altKey: true,
+      handler: () => {
+        const range = quill.getSelection();
+        if (range) {
+          quill.formatLine(range.index, range.length, 'code-block', true);
+        }
+      }
+    });
+
+    // Blockquote shortcut
+    quill.keyboard.addBinding({
+      key: 'Q',
+      ctrlKey: true,
+      altKey: true,
+      handler: () => {
+        const range = quill.getSelection();
+        if (range) {
+          quill.formatLine(range.index, range.length, 'blockquote', true);
+        }
+      }
+    });
+  };
+
+  // Update read-only state
+  useEffect(() => {
+    if (quillRef.current) {
+      quillRef.current.enable(!readOnly);
+    }
+  }, [readOnly]);
+
+  // Exposed methods
+  const getContent = () => {
+    return quillRef.current?.root.innerHTML || '';
+  };
+
+  const getMarkdown = () => {
+    if (!quillRef.current) return '';
+    return convertToMarkdown(quillRef.current.getContents());
+  };
+
+  const setContent = (content: string) => {
+    if (quillRef.current) {
+      quillRef.current.root.innerHTML = content;
+    }
+  };
+
+  const setMarkdown = (markdown: string) => {
+    if (quillRef.current) {
+      quillRef.current.setText(markdown);
+    }
+  };
+
+  const focus = () => {
+    quillRef.current?.focus();
+  };
+
+  const blur = () => {
+    quillRef.current?.blur();
+  };
+
+  // Expose methods via ref if needed
+  React.useImperativeHandle(React.createRef(), () => ({
+    getContent,
+    getMarkdown,
+    setContent,
+    setMarkdown,
+    focus,
+    blur
+  }));
+
+  if (isLoading) {
+    return (
+      <div className={`markdown-editor-loading ${className}`}>
+        <div className="flex items-center justify-center min-h-[200px] text-gray-500">
+          Loading markdown editor...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`markdown-editor-container ${className}`}>
+      <div
+        ref={editorRef}
+        className="markdown-editor min-h-[300px] bg-white border border-gray-300 rounded-md"
+      />
+      
+      {/* Keyboard shortcuts help */}
+      <div className="mt-2 text-xs text-gray-500">
+        <strong>Shortcuts:</strong> Ctrl+Alt+1-3 (Headers), Ctrl+Alt+E (Code block), Ctrl+Alt+Q (Quote)
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownEditor;

--- a/app/src/components/markdown_editor/index.ts
+++ b/app/src/components/markdown_editor/index.ts
@@ -1,0 +1,1 @@
+export { MarkdownEditor, default } from './MarkdownEditor';

--- a/app/src/components/markdown_editor/types.ts
+++ b/app/src/components/markdown_editor/types.ts
@@ -1,0 +1,20 @@
+declare global {
+  interface Window {
+    Quill: typeof import('quill').default;
+    hljs: {
+      highlightAuto: (text: string) => { value: string };
+      highlight: (text: string, options: { language: string }) => { value: string };
+    };
+  }
+}
+
+export interface MarkdownEditorRef {
+  getContent: () => string;
+  getMarkdown: () => string;
+  setContent: (content: string) => void;
+  setMarkdown: (markdown: string) => void;
+  focus: () => void;
+  blur: () => void;
+}
+
+export {};

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -180,6 +180,115 @@ code {
 .response-area::placeholder {
   color: rgba(251, 240, 223, 0.4);
 }
+/* Section styling */
+.section {
+  margin: 3rem 0;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  text-align: left;
+}
+
+.section h2 {
+  font-size: 1.8em;
+  margin-bottom: 1.5rem;
+  color: #fbf0df;
+  text-align: center;
+}
+
+/* Markdown editor specific styles */
+.markdown-editor-container {
+  margin: 1rem 0;
+}
+
+.markdown-editor {
+  background: white;
+  color: #1a1a1a;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.markdown-editor-loading {
+  color: #fbf0df;
+  text-align: center;
+  padding: 2rem;
+}
+
+/* Quill toolbar customization */
+.ql-toolbar {
+  border-top: 1px solid #e0e0e0;
+  border-left: 1px solid #e0e0e0;
+  border-right: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
+  background: #f8f9fa;
+}
+
+.ql-container {
+  border-left: 1px solid #e0e0e0;
+  border-right: 1px solid #e0e0e0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+/* Syntax highlighting enhancements */
+.ql-editor .ql-syntax {
+  background: #f8f9fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 1rem;
+  font-family: 'SF Mono', Monaco, 'Roboto Mono', monospace;
+  font-size: 0.9em;
+  line-height: 1.4;
+  overflow-x: auto;
+}
+
+.ql-editor h1, .ql-editor h2, .ql-editor h3, .ql-editor h4, .ql-editor h5, .ql-editor h6 {
+  color: #1a1a1a;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem 0;
+}
+
+.ql-editor blockquote {
+  border-left: 4px solid #ddd;
+  padding-left: 1rem;
+  margin: 1rem 0;
+  color: #666;
+  font-style: italic;
+}
+
+.ql-editor code {
+  background: #f1f3f4;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-family: 'SF Mono', Monaco, 'Roboto Mono', monospace;
+  font-size: 0.9em;
+}
+
+.ql-editor strong {
+  font-weight: 600;
+}
+
+.ql-editor em {
+  font-style: italic;
+}
+
+.ql-editor a {
+  color: #0366d6;
+  text-decoration: none;
+}
+
+.ql-editor a:hover {
+  text-decoration: underline;
+}
+
+.ql-editor ul, .ql-editor ol {
+  padding-left: 1.5rem;
+}
+
+.ql-editor li {
+  margin: 0.25rem 0;
+}
+
 @media (prefers-reduced-motion) {
   *,
   ::before,


### PR DESCRIPTION
Based on the document found at docs/QuillJs.md create a `MarkdownEdito` component for the `app` at `app/components/markdown_editor` directory that can be then included on the main `App.tsx` component to test its functionality.

The acceptance criteria is to have the component usable on the `app` site, run through the `cargo xtask dev app` command.

It should be fully usable, expose syntax-highlighted markdown, plus code highlighting inside code fences. All assets should *ideally* be imported and bundled through React and Bun --changes to the way they are currently added might need to be changed.