### PR TITLE
Also support `_` to declare `italic`. (vibe-kanban)

### DIFF
--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -2,6 +2,7 @@ import { serve } from "bun";
 import index from "./index.html";
 
 const server = serve({
+  port: 3001,
   routes: {
     // Serve static assets from "../assets".
     "/assets/*": (req: any) => {

--- a/app/src/md_editor/components/Editor.tsx
+++ b/app/src/md_editor/components/Editor.tsx
@@ -143,8 +143,12 @@ const processMarkdownSyntax = (quill: Quill, delta: DeltaT, source: string) => {
   const newCursorPos = absoluteStart + context.content.length;
   quill.setSelection(newCursorPos, 0, 'silent');
   
-  // Reset formatting to normal for subsequent text
-  quill.removeFormat(newCursorPos, 0, 'silent');
+  // Reset formatting state for subsequent typing
+  // We need to explicitly clear the formatting attributes that were applied
+  const formatAttributes = Object.keys(context.pattern.format);
+  formatAttributes.forEach(attr => {
+    quill.format(attr, false, 'silent');
+  });
 };
 
 export type ComponentPropsT = {

--- a/app/src/md_editor/components/Editor.tsx
+++ b/app/src/md_editor/components/Editor.tsx
@@ -142,6 +142,9 @@ const processMarkdownSyntax = (quill: Quill, delta: DeltaT, source: string) => {
   // Position cursor at the end of the formatted text
   const newCursorPos = absoluteStart + context.content.length;
   quill.setSelection(newCursorPos, 0, 'silent');
+  
+  // Reset formatting to normal for subsequent text
+  quill.removeFormat(newCursorPos, 0, 'silent');
 };
 
 export type ComponentPropsT = {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -121,6 +121,12 @@ pub fn api(args: ApiArgs) -> Result<(), Box<dyn Error>> {
 pub fn app_dev() -> Result<(), Box<dyn Error>> {
     bunt::println!("{$magenta}Running App in Dev mode...{/$}");
 
+    // Check if the `app/node_modules` directory exists
+    if !std::path::Path::new("./app/node_modules").exists() {
+        bunt::println!("{$yellow}Running App in Dev mode...{/$}");
+        cmd("bun", vec!["install"]).dir("./app").run()?;
+    }
+
     cmd("bun", vec!["dev"]).dir("./app").run()?;
 
     Ok(())


### PR DESCRIPTION
This:

```
_italic_
```

Should be the same as writing:

```
*italic*
```

And this:

```
**_bold and italic_** 
```

Should be the same as 

```
***Bold and Italic***
```
